### PR TITLE
Fix TemplateSyntaxError in edit_scenario.html

### DIFF
--- a/templates/edit_scenario.html
+++ b/templates/edit_scenario.html
@@ -5,6 +5,7 @@
 {% block title %}Edit Scenario{% endblock %}
 
 {% block content %}
+{% endblock %}
 <div class="container">
     <h1>Edit Scenario</h1>
     <form method="POST" action="{{ url_for('edit_scenario', scenario_name=scenario_name) }}">


### PR DESCRIPTION
Fix TemplateSyntaxError in edit_scenario.html by adding missing endblock tag

This commit fixes a template syntax error in the edit_scenario.html file by adding the missing `{% endblock %}` tag after the content block.

The error was:
```
TemplateSyntaxError: Unexpected end of template - missing endblock tag
```

This fix ensures the template properly closes the content block and resolves the template syntax error.