### PR TITLE
Fix edit_scenario.html template structure

### DIFF
--- a/templates/edit_scenario.html
+++ b/templates/edit_scenario.html
@@ -5,7 +5,6 @@
 {% block title %}Edit Scenario{% endblock %}
 
 {% block content %}
-{% endblock %}
 <div class="container">
     <h1>Edit Scenario</h1>
     <form method="POST" action="{{ url_for('edit_scenario', scenario_name=scenario_name) }}">
@@ -81,6 +80,7 @@
         <a href="{{ url_for('scenarios') }}" class="btn btn-secondary">Cancel</a>
     </form>
 </div>
+{% endblock %}
 
 {% block scripts %}
 <script>


### PR DESCRIPTION

Fix edit_scenario.html template structure - move content inside content block

This commit fixes the template structure in edit_scenario.html by moving the HTML content inside the `{% block content %}` block. The previous structure had content outside the block, which caused the page to appear blank.

The fix ensures that:
- All HTML content is properly contained within the content block
- The template follows proper Jinja2 syntax
- The page will display correctly when accessed via the edit_scenario route

This resolves the issue where the edit scenario page was showing blank content.
