### PR TITLE
Fix download button in devices page

### DIFF
--- a/templates/devices.html
+++ b/templates/devices.html
@@ -11,7 +11,7 @@
     <div>
         <a href="{{ url_for('add_device') }}" class="btn btn-primary">新規追加</a>
         <a href="{{ url_for('import_devices') }}" class="btn btn-success ms-2">インポート</a>
-        <a href="{{ url_for('download_file', filename='devices_updated.yaml') }}" class="btn btn-info ms-2">ダウンロード</a>
+        <a href="{{ url_for('download_file', filename='devices.yaml') }}" class="btn btn-info ms-2">ダウンロード</a>
     </div>
 </div>
 


### PR DESCRIPTION

Fix download button in devices page - change filename from devices_updated.yaml to devices.yaml

This commit fixes the download button in the devices management page by updating the filename from 'devices_updated.yaml' to 'devices.yaml' to match the actual file that exists in the repository.

The download button was not working because it was trying to download a non-existent file. This change ensures that the correct file is downloaded when users click the download button.
