### PR TITLE
Update scenarios page - replace steps count with devices and command groups info

### DIFF
--- a/templates/scenarios.html
+++ b/templates/scenarios.html
@@ -21,7 +21,8 @@
     <thead>
         <tr>
             <th>シナリオ名</th>
-            <th>ステップ数</th>
+            <th>対象デバイス</th>
+            <th>コマンドグループ</th>
             <th>操作</th>
         </tr>
     </thead>
@@ -29,7 +30,24 @@
         {% for scenario_name, scenario in scenarios.items() %}
         <tr>
             <td>{{ scenario_name }}</td>
-            <td>{{ scenario.steps|length }}</td>
+            <td>
+                {% if scenario.devices %}
+                    {% for device_name in scenario.devices %}
+                        {{ device_name }}{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                {% else %}
+                    -
+                {% endif %}
+            </td>
+            <td>
+                {% if scenario.commands %}
+                    {% for command_group in scenario.commands %}
+                        {{ command_group }}{% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                {% else %}
+                    -
+                {% endif %}
+            </td>
             <td>
                 <a href="{{ url_for('edit_scenario', scenario_name=scenario_name) }}" class="btn btn-sm btn-warning">編集</a>
                 <a href="{{ url_for('delete_scenario', scenario_name=scenario_name) }}" class="btn btn-sm btn-danger">削除</a>


### PR DESCRIPTION


Update scenarios page - replace steps count with devices and command groups info

This commit updates the scenarios management page to replace the "ステップ数" (steps count) column with more useful information:

- Added "対象デバイス" (target devices) column to show which devices are included in each scenario
- Added "コマンドグループ" (command groups) column to show which command groups will be executed
- Removed the steps count column as it was not providing useful information

The page now provides a clearer overview of what each scenario includes and targets, making it easier for users to understand the scope of each scenario at a glance.

