### PR TITLE
Convert device selection to checkboxes - support multiple selection for both individual devices and groups

### DIFF
--- a/app.py
+++ b/app.py
@@ -417,23 +417,18 @@ def edit_scenario(scenario_name):
             device_selection = request.form.get('device_selection', 'individual')
             if device_selection == 'group':
                 # グループ選択の場合
-                selected_group = request.form.get('device_group')
-                if selected_group:
-                    # グループに属するデバイスを取得
-                    selected_devices = []
+                selected_groups = request.form.getlist('device_groups')
+                # グループに属するデバイスを取得
+                selected_devices = []
+                for group in selected_groups:
                     for device_name, device in devices.items():
-                        if device.get('group') == selected_group:
+                        if device.get('group') == group:
                             selected_devices.append(device_name)
-                    devices_list = selected_devices
-                else:
-                    devices_list = []
+                devices_list = selected_devices
             else:
                 # 個別デバイス選択の場合
-                selected_device = request.form.get('individual_device')
-                if selected_device:
-                    devices_list = [selected_device]
-                else:
-                    devices_list = []
+                selected_devices = request.form.getlist('individual_devices')
+                devices_list = selected_devices
             
             scenarios[scenario_name] = {
                 'devices': devices_list,

--- a/templates/edit_scenario.html
+++ b/templates/edit_scenario.html
@@ -35,7 +35,7 @@
                     {% for device_name, device in devices.items() %}
                     <div class="col-md-6 mb-2">
                         <div class="form-check">
-                            <input class="form-check-input" type="radio" name="individual_device" id="device_{{ device_name }}" value="{{ device_name }}" {% if device_name in scenario.devices %}checked{% endif %}>
+                            <input class="form-check-input" type="checkbox" name="individual_devices" id="device_{{ device_name }}" value="{{ device_name }}" {% if device_name in scenario.devices %}checked{% endif %}>
                             <label class="form-check-label" for="device_{{ device_name }}">
                                 {{ device_name }} ({{ device.group }})
                             </label>
@@ -43,6 +43,7 @@
                     </div>
                     {% endfor %}
                 </div>
+                <small class="form-text text-muted">Select multiple individual devices</small>
             </div>
             
             <!-- Device groups selection -->
@@ -51,7 +52,7 @@
                     {% for group in device_groups|unique %}
                     <div class="col-md-6 mb-2">
                         <div class="form-check">
-                            <input class="form-check-input" type="radio" name="device_group" id="group_{{ group }}" value="{{ group }}" {% if group in scenario.device_groups|default([]) %}checked{% endif %}>
+                            <input class="form-check-input" type="checkbox" name="device_groups" id="group_{{ group }}" value="{{ group }}" {% if group in scenario.device_groups|default([]) %}checked{% endif %}>
                             <label class="form-check-label" for="group_{{ group }}">
                                 {{ group }}
                             </label>
@@ -59,6 +60,7 @@
                     </div>
                     {% endfor %}
                 </div>
+                <small class="form-text text-muted">Select multiple device groups</small>
             </div>
         </div>
         <div class="form-group">


### PR DESCRIPTION




Convert device selection to checkboxes - support multiple selection for both individual devices and groups

This commit converts the device selection UI from radio buttons to checkboxes to support multiple selection in both individual devices and device groups modes.

## Changes Made:

### Template (templates/edit_scenario.html):
- **Radio buttons → Checkboxes**: Changed from radio buttons to checkboxes for both individual devices and device groups
- **Multiple selection support**: Users can now select multiple individual devices or multiple device groups
- **Improved UX**: Added helpful text hints ("Select multiple individual devices" and "Select multiple device groups")
- **Maintained layout**: Kept the Bootstrap grid system for clean organization

### Backend (app.py):
- **Updated form processing**: Modified to handle checkbox selections using `getlist()` instead of single value retrieval
- **Individual devices**: Now processes `individual_devices` as a list of selected device names
- **Device groups**: Now processes `device_groups` as a list of selected group names
- **Device resolution**: When groups are selected, resolves all devices belonging to those groups
- **Simplified logic**: Removed unnecessary conditional checks since checkboxes can be empty

## Benefits:
- **Multiple selection**: Users can select multiple individual devices or multiple device groups
- **Flexible scenarios**: Enables more complex scenario configurations
- **Better UX**: Checkboxes provide clear visual feedback for multiple selections
- **Maintained functionality**: All existing features continue to work as expected

## How it works:
1. User selects "Select individual devices" → Shows all devices as checkboxes
2. User selects "Select device groups" → Shows all groups as checkboxes
3. User can select multiple options → All selected devices/groups are included in the scenario
4. When groups are selected, all devices in those groups are automatically included

This change provides much more flexibility for scenario creation, allowing users to create scenarios that target multiple devices or multiple device groups simultaneously.


