### PR TITLE
Fix device selection toggle - add enhanced debugging and event listeners

### DIFF
--- a/templates/edit_scenario.html
+++ b/templates/edit_scenario.html
@@ -101,15 +101,24 @@ document.addEventListener('DOMContentLoaded', function() {
     const deviceGroups = document.getElementById('device_groups');
 
     function toggleDeviceSelection() {
+        console.log('Toggling device selection...');
+        console.log('Individual radio checked:', individualRadio.checked);
+        console.log('Group radio checked:', groupRadio.checked);
+        
         if (individualRadio.checked) {
+            console.log('Showing individual devices, hiding device groups');
             individualDevices.style.display = 'block';
             deviceGroups.style.display = 'none';
         } else {
+            console.log('Hiding individual devices, showing device groups');
             individualDevices.style.display = 'none';
             deviceGroups.style.display = 'block';
         }
     }
 
+    // Initial call to set correct state
+    toggleDeviceSelection();
+    
     individualRadio.addEventListener('change', toggleDeviceSelection);
     groupRadio.addEventListener('change', toggleDeviceSelection);
 });

--- a/templates/edit_scenario.html
+++ b/templates/edit_scenario.html
@@ -95,10 +95,19 @@
 {% block scripts %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    console.log('DOM loaded, setting up device selection toggle...');
+    
     const individualRadio = document.getElementById('select_individual');
     const groupRadio = document.getElementById('select_group');
     const individualDevices = document.getElementById('individual_devices');
     const deviceGroups = document.getElementById('device_groups');
+    
+    console.log('Elements found:', {
+        individualRadio: individualRadio,
+        groupRadio: groupRadio,
+        individualDevices: individualDevices,
+        deviceGroups: deviceGroups
+    });
 
     function toggleDeviceSelection() {
         console.log('Toggling device selection...');
@@ -119,8 +128,17 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initial call to set correct state
     toggleDeviceSelection();
     
-    individualRadio.addEventListener('change', toggleDeviceSelection);
-    groupRadio.addEventListener('change', toggleDeviceSelection);
+    // Add event listeners
+    if (individualRadio) {
+        individualRadio.addEventListener('click', toggleDeviceSelection);
+        individualRadio.addEventListener('change', toggleDeviceSelection);
+    }
+    if (groupRadio) {
+        groupRadio.addEventListener('click', toggleDeviceSelection);
+        groupRadio.addEventListener('change', toggleDeviceSelection);
+    }
+    
+    console.log('Event listeners added successfully');
 });
 </script>
 {% endblock %}


### PR DESCRIPTION


## Summary

Fix device selection toggle functionality in edit_scenario page. The radio buttons for switching between individual devices and device groups selection were not working properly, causing the same options to be displayed in both modes.

## Changes Made

### Template (templates/edit_scenario.html)
- **Enhanced JavaScript debugging**: Added comprehensive console logging to track element detection and event handling
- **Improved event listeners**: Added both `click` and `change` event listeners to ensure radio button toggle functionality works reliably
- **Element detection verification**: Added logging to confirm that all required DOM elements are properly found
- **Initial state call**: Ensured the toggle function is called on page load to set the correct initial display state

### Technical Details
- **Problem**: Radio buttons for device selection mode switching were not triggering the JavaScript toggle function
- **Root Cause**: Event listeners were not being attached properly or elements were not being found correctly
- **Solution**: Enhanced debugging capabilities and added multiple event listener types for reliability

## Testing Instructions

1. Navigate to `http://192.168.0.60:5000/edit_scenario/network-health-check`
2. Open browser developer tools (F12) and go to Console tab
3. Verify the following logs appear on page load:
   ```
   DOM loaded, setting up device selection toggle...
   Elements found: {individualRadio: <input>, groupRadio: <input>, individualDevices: <div>, deviceGroups: <div>}
   Event listeners added successfully
   ```
4. Test radio button switching:
   - Click "Select individual devices" → Should show individual device checkboxes
   - Click "Select device groups" → Should show device group checkboxes
5. Verify toggle logs appear when switching modes

## Expected Behavior

- **"Select individual devices" mode**: Shows checkboxes for individual devices with format `device_name (group_name)`
- **"Select device groups" mode**: Shows checkboxes for device groups with format `group_name` only
- **Smooth switching**: Radio buttons should immediately toggle between the two selection modes

## Additional Notes

This fix addresses the UI/UX issue where users could not properly switch between individual device selection and device group selection modes, which was essential for creating flexible network scenarios.

