### PR TITLE
Fix scenario list edit page directory creation and error handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -473,6 +473,9 @@ def edit_scenario_list(list_name):
     """シナリオリストを編集"""
     scenarios = get_scenarios()
     
+    # scenario_listsディレクトリが存在しない場合は作成
+    os.makedirs('scenario_lists', exist_ok=True)
+    
     if request.method == 'POST':
         # シナリオリストの更新処理
         selected_scenarios = request.form.getlist('scenarios')
@@ -485,12 +488,16 @@ def edit_scenario_list(list_name):
             'created_at': datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         }
         
-        # シナリオリストを保存（ファイルやデータベースに保存）
-        with open(f'scenario_lists/{list_name}.yaml', 'w', encoding='utf-8') as f:
-            yaml.dump(scenario_list_data, f, default_flow_style=False, allow_unicode=True)
-        
-        flash('シナリオリストを更新しました', 'success')
-        return redirect(url_for('scenario_lists'))
+        try:
+            # シナリオリストを保存（ファイルやデータベースに保存）
+            with open(f'scenario_lists/{list_name}.yaml', 'w', encoding='utf-8') as f:
+                yaml.dump(scenario_list_data, f, default_flow_style=False, allow_unicode=True)
+            
+            flash('シナリオリストを更新しました', 'success')
+            return redirect(url_for('scenario_lists'))
+        except Exception as e:
+            flash(f'シナリオリストの保存に失敗しました: {str(e)}', 'danger')
+            return redirect(url_for('scenario_lists'))
     else:
         # 編集フォームを表示
         # ここでは既存のシナリオをすべて表示


### PR DESCRIPTION






## Summary

Fixed the FileNotFoundError that occurred when trying to update a scenario list. The issue was that the `scenario_lists` directory was not being created before attempting to save scenario list files. This fix ensures proper directory creation and adds robust error handling for the scenario list editing functionality.

## Changes Made

### Flask Application (app.py)
- **Added directory creation**: `os.makedirs('scenario_lists', exist_ok=True)` ensures the directory exists before file operations
- **Enhanced error handling**: Added try-catch block around file save operations
- **User feedback**: Added flash messages for both success and error cases

## Technical Details

### Problem
- Users encountered `FileNotFoundError: [Errno 2] No such file or directory: 'scenario_lists/network-health-check.yaml'`
- The error occurred when clicking the "更新" (Update) button on the scenario list edit page
- The `scenario_lists` directory was not being created automatically

### Solution
- **Directory Creation**: Added automatic directory creation with `os.makedirs()`
- **Error Handling**: Wrapped file operations in try-catch blocks
- **User Feedback**: Added appropriate flash messages for success/error states

### Code Changes
```python
# Added directory creation
os.makedirs('scenario_lists', exist_ok=True)

# Added error handling
try:
    with open(f'scenario_lists/{list_name}.yaml', 'w', encoding='utf-8') as f:
        yaml.dump(scenario_list_data, f, default_flow_style=False, allow_unicode=True)
    
    flash('シナリオリストを更新しました', 'success')
    return redirect(url_for('scenario_lists'))
except Exception as e:
    flash(f'シナリオリストの保存に失敗しました: {str(e)}', 'danger')
    return redirect(url_for('scenario_lists'))
```

## Testing Instructions

1. Navigate to `http://192.168.0.60:5000/edit_scenario_list/network-health-check`
2. Select multiple scenarios using the checkboxes
3. Click the "更新" (Update) button
4. Verify you are redirected to the scenario lists page
5. Check for success message: "シナリオリストを更新しました"
6. Verify the file `scenario_lists/network-health-check.yaml` is created
7. Test error handling by trying to save with invalid data

## Expected Behavior

- **Before Update**: `scenario_lists` directory does not exist
- **After Update**: `scenario_lists` directory is automatically created
- **File Creation**: Scenario list YAML file is successfully created
- **User Feedback**: Success message is displayed on successful save
- **Error Handling**: Error message is displayed if save fails

## Additional Notes

This fix resolves the critical issue that was preventing users from creating and updating scenario lists. The automatic directory creation ensures the application works reliably across different environments, and the enhanced error handling provides better user experience by giving clear feedback about the operation status.

The scenario list functionality is now fully functional, allowing users to:
- Create scenario lists by selecting multiple scenarios
- Save scenario lists with proper directory structure
- Receive clear feedback about save operations
- Continue using the application without manual directory setup





