### PR TITLE
Update scenario lists page to show selected scenario names instead of count

### DIFF
--- a/app.py
+++ b/app.py
@@ -466,7 +466,23 @@ def delete_scenario(scenario_name):
 def scenario_lists():
     """シナリオ一覧ページ"""
     scenarios = get_scenarios()
-    return render_template('scenario_lists.html', scenarios=scenarios)
+    
+    # 保存されたシナリオリストを読み込む
+    scenario_lists_data = {}
+    try:
+        if os.path.exists('scenario_lists'):
+            for filename in os.listdir('scenario_lists'):
+                if filename.endswith('.yaml'):
+                    list_name = filename[:-5]  # .yamlを除く
+                    with open(f'scenario_lists/{filename}', 'r', encoding='utf-8') as f:
+                        list_data = yaml.safe_load(f)
+                        if list_data and 'scenarios' in list_data:
+                            scenario_lists_data[list_name] = list_data['scenarios']
+    except Exception as e:
+        print(f"シナリオリストの読み込みエラー: {e}")
+        scenario_lists_data = {}
+    
+    return render_template('scenario_lists.html', scenarios=scenarios, scenario_lists=scenario_lists_data)
 
 @app.route('/edit_scenario_list/<list_name>', methods=['GET', 'POST'])
 def edit_scenario_list(list_name):

--- a/templates/scenario_lists.html
+++ b/templates/scenario_lists.html
@@ -28,7 +28,13 @@
             {% for list_name, scenarios in scenarios.items() %}
             <tr>
                 <td>{{ list_name }}</td>
-                <td>{{ scenarios|length }}</td>
+                <td>
+                    {% if scenario_lists[list_name] %}
+                        {{ scenario_lists[list_name]|length }}
+                    {% else %}
+                        0
+                    {% endif %}
+                </td>
                 <td>
                     <a href="{{ url_for('edit_scenario_list', list_name=list_name) }}" class="btn btn-sm btn-warning">編集</a>
                     <a href="{{ url_for('delete_scenario', scenario_name=list_name) }}" class="btn btn-sm btn-danger">削除</a>

--- a/templates/scenario_lists.html
+++ b/templates/scenario_lists.html
@@ -30,9 +30,13 @@
                 <td>{{ list_name }}</td>
                 <td>
                     {% if scenario_lists[list_name] %}
-                        {{ scenario_lists[list_name]|length }}
+                        <div class="scenario-list">
+                            {% for scenario_name in scenario_lists[list_name] %}
+                                <span class="badge bg-secondary me-1">{{ scenario_name }}</span>
+                            {% endfor %}
+                        </div>
                     {% else %}
-                        0
+                        <span class="text-muted">選択されたシナリオなし</span>
                     {% endif %}
                 </td>
                 <td>


### PR DESCRIPTION






## Summary

Updated the scenario lists management page to display the actual selected scenario names instead of showing a fixed count. This provides users with a clear view of which scenarios are included in each scenario list, improving the user experience and making the page more informative.

## Changes Made

### Template (templates/scenario_lists.html)
- **Replaced count display**: Changed from showing scenario count to displaying actual scenario names
- **Added visual badges**: Used Bootstrap badges (`badge bg-secondary`) to display scenario names
- **Improved layout**: Scenario names are displayed horizontally with proper spacing
- **Added fallback message**: Shows "選択されたシナリオなし" when no scenarios are selected

## Technical Details

### Problem
- The scenario lists page was showing a fixed count of 7 for all scenario lists
- Users couldn't see which specific scenarios were included in each list
- This made it difficult to understand the content of each scenario list at a glance

### Solution
- **Dynamic content display**: Now reads and displays the actual scenario names from saved scenario lists
- **Visual formatting**: Uses Bootstrap badges for better visual presentation
- **Responsive layout**: Scenario names are displayed in a horizontal layout that adapts to different screen sizes

### Code Changes
```html
<!-- Before: Show count -->
<td>{{ scenarios|length }}</td>

<!-- After: Show scenario names -->
<td>
    {% if scenario_lists[list_name] %}
        <div class="scenario-list">
            {% for scenario_name in scenario_lists[list_name] %}
                <span class="badge bg-secondary me-1">{{ scenario_name }}</span>
            {% endfor %}
        </div>
    {% else %}
        <span class="text-muted">選択されたシナリオなし</span>
    {% endif %}
</td>
```

## Testing Instructions

1. Navigate to `http://192.168.0.60:5000/scenario_lists`
2. Verify that scenario names are displayed as badges instead of numbers
3. Check that multiple scenarios are shown when multiple scenarios are selected
4. Verify that "選択されたシナリオなし" is shown when no scenarios are selected
5. Test editing a scenario list and verify the display updates correctly

## Expected Behavior

- **Before**: All scenario lists showed "7" in the scenario count column
- **After**: Each scenario list shows the actual scenario names included in that list
- **Visual**: Scenario names appear as gray badges in a horizontal layout
- **Fallback**: Empty lists show "選択されたシナリオなし" message
- **Dynamic**: Display updates when scenario lists are edited

## Additional Notes

This change significantly improves the usability of the scenario lists management page by providing immediate visual feedback about the content of each scenario list. Users can now quickly identify which scenarios are included in each list without needing to click the edit button.

The use of Bootstrap badges ensures consistent styling with the rest of the application, and the horizontal layout makes efficient use of table space while maintaining readability. This enhancement makes the scenario list management feature much more user-friendly and informative.

The implementation is backward compatible and handles edge cases such as empty scenario lists gracefully, ensuring a smooth user experience across all scenarios.</arg_value>
