### PR TITLE
Fix run_scenario function TypeError - add optional scenario_name parameter

### DIFF
--- a/app.py
+++ b/app.py
@@ -529,9 +529,11 @@ def execute():
     return render_template('execute.html', devices=devices, command_groups=command_groups, scenarios=scenarios, scenario_lists=scenarios)
 
 @app.route('/run_scenario', methods=['POST'])
-def run_scenario():
+def run_scenario(scenario_name=None):
     """シナリオを実行"""
-    scenario_name = request.form['scenario_name']
+    if scenario_name is None:
+        scenario_name = request.form['scenario_name']
+    
     scenarios = get_scenarios()
     
     if scenario_name not in scenarios:


### PR DESCRIPTION







## Summary

Fixed the TypeError that occurred when trying to execute scenario lists. The issue was that the `run_scenario()` function was defined without parameters but was being called with a `scenario_name` argument from the scenario list execution logic. This fix adds an optional parameter to make the function compatible with both direct calls and programmatic execution.

## Changes Made

### Flask Application (app.py)
- **Added optional parameter**: Modified `run_scenario()` function to accept an optional `scenario_name` parameter
- **Backward compatibility**: Maintained compatibility with existing POST form submissions
- **Flexible execution**: Now supports both direct function calls and form-based execution

## Technical Details

### Problem
- Users encountered `TypeError: run_scenario() takes 0 positional arguments but 1 was given`
- This occurred when the scenario list execution logic tried to call `run_scenario(scenario_name)`
- The function was originally defined without parameters, causing the error when called with arguments

### Solution
- **Parameter Addition**: Added `scenario_name=None` as an optional parameter
- **Conditional Logic**: Added logic to use the parameter if provided, otherwise fall back to form data
- **Maintained Compatibility**: Existing POST form submissions continue to work unchanged

### Code Changes
```python
# Before: No parameters
def run_scenario():
    scenario_name = request.form['scenario_name']

# After: Optional parameter
def run_scenario(scenario_name=None):
    if scenario_name is None:
        scenario_name = request.form['scenario_name']
```

## Testing Instructions

1. Navigate to `http://192.168.0.60:5000/scenario_lists`
2. Click the "実行" button for any scenario list
3. Verify that the TypeError no longer occurs
4. Check that the execution starts successfully
5. Test direct URL access: `http://192.168.0.60:5000/execute_scenario_post?scenario_name=network-health-check`
6. Verify that individual scenario execution still works
7. Test scenario list execution with multiple scenarios

## Expected Behavior

- **Before**: TypeError when executing scenario lists
- **After**: Scenario lists execute successfully without errors
- **Individual Execution**: Single scenarios continue to work as before
- **List Execution**: Multiple scenarios in a list execute sequentially
- **Error Handling**: Proper error handling for missing scenarios

## Additional Notes

This fix resolves the critical TypeError that was preventing scenario list functionality from working. The implementation now properly handles both individual scenario execution and batch execution through scenario lists.

The solution maintains backward compatibility with existing functionality while adding the flexibility needed for scenario list execution. This makes the application more robust and user-friendly, allowing users to execute both individual scenarios and collections of scenarios seamlessly.

The fix is minimal and focused, addressing only the specific TypeError without affecting other parts of the application. This ensures a low-risk change that can be safely deployed to production.</arg_value>

